### PR TITLE
Update readme on creating env variable locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To run the example locally you need to:
 
 1. Sign up for accounts with the AI providers you want to use (e.g., OpenAI, Anthropic).
 2. Obtain API keys for each provider.
-3. Set the required environment variables as shown in the `.env.example` file, but in a new file called `.env`.
+3. Set the required environment variables as shown in the `.env.example` file, but in a new file called `.env.local`.
 4. `pnpm install` to install the required Node dependencies.
 5. `virtualenv venv` to create a virtual environment.
 6. `source venv/bin/activate` to activate the virtual environment.


### PR DESCRIPTION
Update `.env` to `.env.local` since the the `load_dotenv` in fastapi is pointing to `.env.local`